### PR TITLE
Change Next Due Date on Invoice Changes

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -68,11 +68,10 @@ class InvoicesController < ApplicationController
     invoice = Invoice.find(params[:id])
 
     full_params = invoice_params.to_h
-    full_params.merge!({invoice_items_attributes: full_params.delete(:invoice_items)})
-
     full_params.merge!({invoice_adjustments_attributes: full_params.delete(:invoice_adjustments) || []})
+    full_params.merge!({invoice_items_attributes: full_params.delete(:invoice_items) || []})
 
-    invoice.update(full_params)
+    invoice.update!(full_params)
 
     if invoice.errors.none?
       render json: invoice.as_json(

--- a/app/javascript/components/Invoices/InvoiceForm.jsx
+++ b/app/javascript/components/Invoices/InvoiceForm.jsx
@@ -105,8 +105,9 @@ const NewInvoice = ({ invoice: loadedInvoice, onSubmit, mode }) => {
         <Grid item xs={12}>
           <Paper sx={{ my: 2, p: 2 }}>
             <Typography>
-              Note: Manually generated invoices do not modify the Next Due Date
-              for any attached rental agreements.
+              Note: Updating an invoice will modify the Rental Agreements Next
+              Due Date. You will need to manually adjust the date if you are
+              back-dating entries and do not wish for the date to change.
             </Typography>
           </Paper>
         </Grid>

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -2,7 +2,7 @@ class Invoice < ApplicationRecord
   include Searchable
   belongs_to :customer
   belongs_to :payment, optional: true
-  has_many :invoice_items, dependent: :destroy
+  has_many :invoice_items, dependent: :destroy, inverse_of: :invoice
   has_many :invoice_adjustments, dependent: :destroy
   has_many :rental_agreements, through: :invoice_items, source: :item, source_type: "RentalAgreement"
 

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,4 +1,22 @@
 class InvoiceItem < ApplicationRecord
-  belongs_to :invoice
+  belongs_to :invoice, inverse_of: :invoice_items
   belongs_to :item, polymorphic: true
+
+  after_create :after_create_invoice_item
+  after_update :after_update_invoice_item
+
+  private
+
+  def after_create_invoice_item
+    return unless item.respond_to?(:after_create_invoice_item)
+
+    item.after_create_invoice_item(item_count)
+  end
+
+  def after_update_invoice_item
+    return unless item.respond_to?(:after_update_invoice_item)
+    old_item_count = previous_changes['item_count'][0]
+
+    item.after_update_invoice_item(item_count, old_item_count)
+  end
 end

--- a/app/models/rental_agreement.rb
+++ b/app/models/rental_agreement.rb
@@ -49,6 +49,21 @@ class RentalAgreement < ApplicationRecord
     update(next_due_date: next_due_date + (purchase_count * frequency_in_months.to_i.months))
   end
 
+  def after_create_invoice_item(count)
+    new_due_date = next_due_date
+    add_months = frequency_in_months * count
+    
+    if new_due_date.is_a?(Date) && add_months.is_a?(Integer)
+      update(next_due_date: (new_due_date + add_months.months))
+    end
+  end
+
+  def after_update_invoice_item(count, old_count)
+    new_count = count - old_count
+
+    after_create_invoice_item(new_count)
+  end
+
   private
 
   def update_unit_occupancy

--- a/app/workers/billing_cycle_worker.rb
+++ b/app/workers/billing_cycle_worker.rb
@@ -20,9 +20,9 @@ class BillingCycleWorker
 
           invoice.save!
 
-          invoice.rental_agreements.each do |agreement|
-            agreement.push_due_date!
-          end
+          # invoice.rental_agreements.each do |agreement|
+          #   agreement.push_due_date!
+          # end
         end
       rescue StandardError=> e
         logger.error e.message

--- a/spec/factories/invoice.rb
+++ b/spec/factories/invoice.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+
+  factory :invoice do
+    association :customer
+    state { "pending" }
+    subtotal_in_cents { 10000 }
+    total_in_cents { 10000 }
+    date { Faker::Date.backward }
+
+    after(:create) do |invoice|
+      rental_agreement = create(:rental_agreement, customer: invoice.customer)
+      create(:invoice_item, invoice: invoice, item: rental_agreement)
+    end
+  end
+end

--- a/spec/factories/invoice_item.rb
+++ b/spec/factories/invoice_item.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+
+  factory :invoice_item do
+    association :invoice
+    association :item, factory: :rental_agreement
+    item_count { 1 }
+  end
+end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe InvoiceItem, type: :model do
+  describe "Update Rental Agreement" do
+    before do
+      @customer = create(:customer)
+      @rental_agreement = create(:rental_agreement, customer: @customer)
+    end
+
+    it "changes the date on create" do
+      @invoice = create(:invoice, customer: @customer)
+      next_due_date = @rental_agreement.next_due_date
+
+      add_months = @rental_agreement.frequency_in_months.months
+      new_due_date = next_due_date + add_months
+
+      create(:invoice_item, invoice: @invoice, item: @rental_agreement)
+
+      expect(@rental_agreement.reload.next_due_date).to eq(new_due_date)
+    end
+
+    it "updates the date on update" do
+      @invoice = create(:invoice, customer: @customer)
+      next_due_date = @rental_agreement.next_due_date
+
+      add_months = (@rental_agreement.frequency_in_months.months)
+      new_due_date = next_due_date + add_months
+
+      @item = create(:invoice_item, invoice: @invoice, item: @rental_agreement)
+
+      expect(@rental_agreement.reload.next_due_date).to eq(new_due_date)
+
+      updated_due_date = @rental_agreement.next_due_date
+      update_count = 3 - @item.item_count
+      update_months = (@rental_agreement.frequency_in_months * update_count).months
+
+      updated_due_date = updated_due_date + update_months
+
+      @item.update(item_count: 3)
+
+      expect(@rental_agreement.reload.next_due_date).to eq(updated_due_date)
+    end
+
+    it "updates the date on update (negative count)" do
+      @invoice = create(:invoice, customer: @customer)
+      next_due_date = @rental_agreement.next_due_date
+
+
+      add_months = (@rental_agreement.frequency_in_months * 3).months
+      new_due_date = next_due_date + add_months
+
+      @item = create(
+        :invoice_item, 
+        invoice: @invoice, 
+        item: @rental_agreement, 
+        item_count: 3
+      )
+
+      expect(@rental_agreement.reload.next_due_date).to eq(new_due_date)
+
+      updated_due_date = @rental_agreement.next_due_date
+      update_count = 1 - @item.item_count
+      update_months = (@rental_agreement.frequency_in_months * update_count).months
+
+      updated_due_date = updated_due_date + update_months
+
+      @item.update(item_count: 1)
+
+      expect(@rental_agreement.reload.next_due_date).to eq(updated_due_date)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,7 +45,7 @@ RSpec.configure do |config|
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
   config.before(:suite) do
-    Rails.application.load_seed
+    # Rails.application.load_seed
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/requests/invoices_spec.rb
+++ b/spec/requests/invoices_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe "Invoices", type: :request do
+  describe "GET /api/invoices" do
+    before do
+      @invoice = create(:invoice)
+    end
+
+    it "returns a list of invoices" do
+      get "/api/invoices", headers: auth_headers
+
+      data = JSON.parse(response.body)
+      returned_ids = data.map { |x| x["id"] }
+
+      expect(response).to have_http_status(:success)
+      expect(returned_ids.include?(@invoice.id)).to be_truthy
+    end
+  end
+
+  describe "POST /api/invoices" do
+    before do
+      @rental_agreement = create(:rental_agreement)
+      @invoice = create(:invoice)
+    end
+
+    it "creates a new invoice" do
+      post "/api/invoices", headers: auth_headers, as: :json, params: {
+        invoice: {
+          customer_id: @rental_agreement.customer.id,
+          date: Date.today,
+          subtotal_in_cents: @rental_agreement.price_in_cents,
+          total_in_cents: @rental_agreement.price_in_cents,
+          invoice_items: [{item_id: @rental_agreement.id, item_type: @rental_agreement.class.to_s, item_count: 1}]
+        }
+      }
+
+      data = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      expect(data["id"]).to_not eq(nil)
+      expect(data["invoice_items"].length).to eq(1)
+    end
+
+    it "creates a new invoice with an adjustment" do
+      post "/api/invoices", headers: auth_headers, as: :json, params: {
+        invoice: {
+          customer_id: @rental_agreement.customer.id,
+          date: Date.today,
+          subtotal_in_cents: @rental_agreement.price_in_cents - 500,
+          total_in_cents: @rental_agreement.price_in_cents - 500,
+          invoice_items: [{item_id: @rental_agreement.id, item_type: @rental_agreement.class.to_s, item_count: 1}],
+          invoice_adjustments: [{type_of: "discount", reason: "prepay", price_in_cents: 500}]
+        }
+      }
+
+      data = JSON.parse(response.body)
+      expect(data["id"]).to_not eq(nil)
+      expect(data["invoice_adjustments"].length).to eq(1)
+    end
+  end
+
+  describe "PUT /api/invoices" do
+    before do
+      @invoice = create(:invoice)
+      @rental_agreement = create(:rental_agreement, customer: @invoice.customer)
+      @invoice.reload
+      @invoice_item = @invoice.invoice_items.first
+    end
+
+    it "updates an existing invoice" do
+      put "/api/invoices/#{@invoice.id}", headers: auth_headers, as: :json, params: {
+        invoice: {
+          state: "sent",
+          date: 1.day.ago.to_s,
+          invoice_items: [@invoice_item, {item_id: @rental_agreement.id, item_type: @rental_agreement.class.to_s, item_count: "2"}],
+        }
+      }
+      data = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+
+      expect(data["date"]).to eq(1.day.ago.to_date.to_s)
+      expect(data["state"]).to eq("sent")
+      expect(data["invoice_items"].length).to eq(2)
+    end
+
+    it "removes invoice items that don't belong to the customer" do
+      @agreement = create(:rental_agreement)
+
+      put "/api/invoices/#{@invoice.id}", headers: auth_headers, as: :json, params: {
+        invoice: {
+          state: "sent",
+          date: 1.day.ago.to_s,
+          invoice_items: [@invoice_item, {item_id: @agreement.id, item_type: @agreement.class.to_s, item_count: "2"}],
+        }
+      }
+      data = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      expect(data["invoice_items"].length).to eq(1)
+    end
+  end
+  
+  describe "DELETE /api/invoices" do
+    it "deletes an existing invoice" do
+      invoice = create(:invoice)
+      invoice_id = invoice.id
+
+      delete "/api/invoices/#{invoice_id}", headers: auth_headers
+
+      expect(response).to have_http_status(:success)
+      expect(Invoice.find_by(id: invoice_id)).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
In order to automate the process of changing next due dates whenever invoices are updated or created this commit makes it so that when an invoice_item is created it will automatically push the next_due_date of the rental agreement.

In the event an invoice is updated it will modify the next_due_date based on the difference of the new and old item_count.