### PR TITLE
Fix Manual Invoices Including Ended Agreements

### DIFF
--- a/app/javascript/components/Invoices/InvoiceForm.jsx
+++ b/app/javascript/components/Invoices/InvoiceForm.jsx
@@ -56,7 +56,9 @@ const NewInvoice = ({ invoice: loadedInvoice, onSubmit, mode }) => {
             item_count: 1,
           };
 
-          invoice_items.push(newInvoiceItem);
+          if (agreement.active) {
+            invoice_items.push(newInvoiceItem);
+          }
         });
 
         dispatch({ type: "invoice_items", value: invoice_items });

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,7 +15,7 @@ class Customer < ApplicationRecord
   end
 
   def as_json(args = {})
-    super({include: { address: [], invoices: [], payments: [], rental_agreements: { include: {unit: {}}, methods: :name }}}.merge(args))
+    super({include: { address: [], invoices: [], payments: [], rental_agreements: { include: {unit: {}}, methods: [:name, :active] }}}.merge(args))
   end
 
   def self.searchable_attributes

--- a/app/models/rental_agreement.rb
+++ b/app/models/rental_agreement.rb
@@ -43,6 +43,10 @@ class RentalAgreement < ApplicationRecord
     last_invoice.date > (date - frequency_in_months.to_i.months)
   end
 
+  def active
+    end_date.blank? || end_date >= Time.zone.now.to_date
+  end
+
   def push_due_date!(purchase_count = 1)
     return if next_due_date.blank?
 


### PR DESCRIPTION
In order to prevent manually created invoices from showing inactive Rental Agreements this commit makes it so that we exclude them from the list of agreements on the New Invoice form.