### PR TITLE
Fix Empty Invoice Item Check

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -23,7 +23,7 @@ class Invoice < ApplicationRecord
   end
 
   def empty_item?(item_attr)
-    item_attr['item_count'].blank? || item_attr['item_count'].try(:zero?)
+    item_attr['item_count'].blank? || item_attr['item_count'].to_i.try(:zero?)
   end
 
   def empty_adjustment?(item_attr)


### PR DESCRIPTION
In order to prevent '0' from being accepted as a valid invoice item amount this commit fixes it so that the `empty_item?` check on an Invoice first converts the item_count to an intenger before checking if it is zero.