### PR TITLE
Reset Invoice State on Index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,6 +342,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/app/javascript/components/Invoices/index.jsx
+++ b/app/javascript/components/Invoices/index.jsx
@@ -29,6 +29,8 @@ const Invoices = ({ children }) => {
           });
           navigate("/invoices");
         });
+    } else {
+      setInvoice(null);
     }
   }, [invoiceId]);
 

--- a/app/javascript/components/reducer.js
+++ b/app/javascript/components/reducer.js
@@ -1,14 +1,14 @@
-import { merge, set } from "lodash";
+import { assign, merge, set } from "lodash";
 
 export default function reducer(state, action) {
   // console.log("oldState", state, action);
   if (action.type == "initialize") {
     // this takes the default state passed in to the reducer
     // and merges in a state over top of it.
-    let newState = { ...state };
-    merge(newState, action.value);
+    // let newState = { ...state };
+    // merge(newState, action.value);
     // console.log("newState", newState);
-    return merge({ ...state }, action.value);
+    return assign({ ...state }, action.value);
   }
 
   if (action.type == "reset") {

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,16 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  # database: db/development.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: <%= ENV.fetch("DATABASE_NAME") { "meramec_development" } %>
+  pool: 5
+  username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { "password" } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
+  port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
+
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
Whenever a user goes from an Invoice to the index list, to a different invoice it was preserving some of the previous invoice items across the state. This commit makes it so that we nullify the invoice when we go to the index.

Additionally this commit fixes an error where we were using merge rather than assign on initialize. This could cause issues where states would begin to overlap rather than truly initialize/reset a value. E.g. as with the problem above we were getting objects in our invoice_items array we didn't expect due to them being included as merge kept them rather than overwriting them when updating the state.